### PR TITLE
Add polynomial regression baseline

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+python3 - "${@}" <<'PY'
+import sys
+if len(sys.argv)!=4:
+    sys.exit(1)
+try:
+    d=float(sys.argv[1])
+    m=float(sys.argv[2])
+    r=float(sys.argv[3])
+except ValueError:
+    sys.exit(1)
+coeff=[-165.13884826523372,88.17230215631525,0.4069550111070743,1.2116765573935222,-2.5902746074706986,3.526925506669356e-05,-0.0002785201970856102,0.01451018774824324,-0.008909396689364302,-0.00011392118366372606]
+features=[1,d,m,r,d*d,m*m,r*r,d*m,d*r,m*r]
+result=sum(c*f for c,f in zip(coeff,features))
+print(f"{result:.2f}")
+PY


### PR DESCRIPTION
## Summary
- implement `run.sh` using a simple polynomial regression model

## Testing
- `python3 - <<'EOF'
import json, math, statistics
coeff=[-165.13884826523372,88.17230215631525,0.4069550111070743,1.2116765573935222,-2.5902746074706986,3.526925506669356e-05,-0.0002785201970856102,0.01451018774824324,-0.008909396689364302,-0.00011392118366372606]
with open('public_cases.json') as f:data=json.load(f)
errors=[abs(sum(c*f for c,f in zip(coeff,[1,d:=c['input']['trip_duration_days'],m:=c['input']['miles_traveled'],r:=c['input']['total_receipts_amount'],d*d,m*m,r*r,d*m,d*r,m*r]))-c['expected_output']) for c in data]
print('Average error',statistics.mean(errors))
print('Max error',max(errors))
print('Exact <1',sum(e<1 for e in errors))
EOF

------
https://chatgpt.com/codex/tasks/task_e_684476ac5c18832b8ecc49cff54e59d7