### PR TITLE
Add reimbursement rules summary

### DIFF
--- a/TRAVEL_RULES.md
+++ b/TRAVEL_RULES.md
@@ -1,0 +1,49 @@
+# Reconstructed Reimbursement Rules
+
+This document summarizes potential reimbursement rules gleaned from employee interviews in `INTERVIEWS.md`. The rules are speculative and sometimes contradictory.
+
+## Base Per Diem
+- Standard daily rate appears to be around **$100/day**【F:INTERVIEWS.md†L107-L108】.
+- **5-day trips** usually get a bonus, but there are exceptions where identical 5‑day trips did not receive it【F:INTERVIEWS.md†L111-L114】.
+
+## Mileage Reimbursement
+- First ~100 miles get the full rate of about **58¢ per mile**, after which the per‑mile rate decreases according to a curve【F:INTERVIEWS.md†L121-L129】.
+- High mileage with low spending tends to be rewarded, while low mileage with high spending is penalized【F:INTERVIEWS.md†L489-L493】.
+- Mileage bonuses seem optimized around **180‑220 miles per day**; driving excessively (≈400 miles/day) results in reduced bonuses【F:INTERVIEWS.md†L415-L418】.
+
+## Spending and Receipts
+- Reimbursement does **not** scale linearly with spending. Medium‑high receipt totals (about **$600‑$800**) get better treatment; spending more yields diminishing returns【F:INTERVIEWS.md†L137-L147】.
+- Submitting very small receipts can reduce the total reimbursement; some employees choose not to submit amounts like **$12**【F:INTERVIEWS.md†L249-L256】【F:INTERVIEWS.md†L331-L332】.
+- There may be a rounding quirk where receipts ending in **.49** or **.99** get rounded up in the employee’s favor【F:INTERVIEWS.md†L181-L185】.
+
+## Optimal Spending Ranges by Trip Length
+- **Short trips:** keep spending under **$75/day**.
+- **Medium trips (4‑6 days):** spending up to **$120/day** is tolerated.
+- **Long trips:** keep spending under **$90/day** to avoid penalties【F:INTERVIEWS.md†L425-L428】.
+
+## Trip Duration Effects
+- Many employees mention a **sweet spot around 4‑6 days**, with longer or shorter trips yielding worse reimbursements【F:INTERVIEWS.md†L337-L339】.
+- Trips over **8 days** with high spending incur a penalty (the “vacation penalty”)【F:INTERVIEWS.md†L489-L492】.
+
+## Timing of Submission
+- Some believe the system is more generous at certain times: early vs. late month, end of quarter, or specific days of the week.
+  - Tuesday and Thursday submissions tend to be higher, while Friday is worse【F:INTERVIEWS.md†L439-L444】.
+  - End-of-quarter or new moon periods may yield higher amounts【F:INTERVIEWS.md†L451-L457】, though others find no seasonal pattern【F:INTERVIEWS.md†L117-L119】.
+
+## Historical Behavior & Learning
+- The system may remember past submissions—frequent high expenses can reduce future payouts, while modest spending may increase them【F:INTERVIEWS.md†L69-L73】.
+- Some employees suspect the system adapts or learns over time, adjusting to individual profiles【F:INTERVIEWS.md†L507-L509】.
+
+## Efficiency Bonuses
+- Covering significant ground in a short time is rewarded (“efficiency bonus”)【F:INTERVIEWS.md†L79-L80】【F:INTERVIEWS.md†L161-L163】.
+- Specific threshold: 5‑day trips with at least 180 miles/day and spending under $100/day reportedly guarantee a bonus (the “sweet spot combo”)【F:INTERVIEWS.md†L489-L490】.
+
+## Departmental Differences
+- Sales teams often receive higher reimbursements, possibly due to experience with the system. Other departments see mixed results【F:INTERVIEWS.md†L347-L353】.
+
+## Notable Contradictions
+- **Seasonality:** Marcus from Sales suggests early month trips pay more【F:INTERVIEWS.md†L23-L24】, and that Q4 is generous【F:INTERVIEWS.md†L63-L64】, yet others (e.g., Lisa) find no consistent quarterly pattern【F:INTERVIEWS.md†L117-L119】.
+- **5-day bonus inconsistency:** Lisa observed a 5‑day trip without the usual bonus, contradicting the “always bonus” rule【F:INTERVIEWS.md†L111-L114】.
+- **Mileage vs. effort:** Marcus saw an 8‑day high‑mileage trip pay very well, whereas a 7‑day low‑mileage conference paid poorly, suggesting unspoken effort factors【F:INTERVIEWS.md†L27-L30】.
+
+These interviews imply a complex formula involving trip length, mileage efficiency, spending ranges, timing, and perhaps randomness or adaptive behavior. Employees lack definitive knowledge, but the trends above emerge from their experiences.


### PR DESCRIPTION
## Summary
- Documented inferred rules for travel reimbursements from interviews

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844871f951c832b8ad3cb602a7b8081